### PR TITLE
Update dependencies: gym should be gymnasium now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license = BSD 3-Clause
 packages = find:
 install_requires =
     numpy
-    gym
+    gymnasium
     torch
     trifinger_rl_datasets
 


### PR DESCRIPTION
Not tested but grepping the repo for "gym" only shows one import `import gymnasium as gym`.